### PR TITLE
Updates to Linux 4.20

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -3,8 +3,8 @@ require kselftests.inc
 
 DESCRIPTION = "Generic Linux mainline kernel"
 
-PV = "4.19+git${SRCPV}"
-SRCREV_kernel = "84df9525b0c27f3ebc2ebb1864fa62a97fdedb7d"
+PV = "4.20+git${SRCPV}"
+SRCREV_kernel = "8fe28cb58bcb235034b64cbbb7550a8a43fd88be"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -3,8 +3,8 @@ require kselftests.inc
 
 DESCRIPTION = "Generic Linux next kernel"
 
-PV = "4.19+git${SRCPV}"
-SRCREV_kernel = "84df9525b0c27f3ebc2ebb1864fa62a97fdedb7d"
+PV = "4.20+git${SRCPV}"
+SRCREV_kernel = "8fe28cb58bcb235034b64cbbb7550a8a43fd88be"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.20.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.20.bb
@@ -1,0 +1,118 @@
+require linux.inc
+require kselftests.inc
+
+DESCRIPTION = "Generic Linux Stable RC 4.20 LTS kernel"
+
+PV = "4.20+git${SRCPV}"
+SRCREV_kernel = "8fe28cb58bcb235034b64cbbb7550a8a43fd88be"
+SRCREV_FORMAT = "kernel"
+
+SRC_URI = "\
+    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git;protocol=https;branch=linux-4.20.y;name=kernel \
+    file://lkft.config;subdir=git/kernel/configs \
+    file://distro-overrides.config;subdir=git/kernel/configs \
+    file://systemd.config;subdir=git/kernel/configs \
+"
+
+S = "${WORKDIR}/git"
+
+COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
+KERNEL_IMAGETYPE ?= "Image"
+KERNEL_CONFIG_FRAGMENTS += "\
+    ${S}/kernel/configs/lkft.config \
+    ${S}/kernel/configs/distro-overrides.config \
+    ${S}/kernel/configs/systemd.config \
+"
+
+# make[3]: *** [scripts/extract-cert] Error 1
+DEPENDS += "openssl-native"
+HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
+
+do_configure() {
+    touch ${B}/.scmversion ${S}/.scmversion
+
+    # While kernel.bbclass has an architecture mapping, we can't use it because
+    # the kernel config file has a different name.
+    case "${HOST_ARCH}" in
+      aarch64)
+        cp ${S}/arch/arm64/configs/defconfig ${B}/.config
+        # https://bugs.linaro.org/show_bug.cgi?id=3769
+        echo 'CONFIG_ARM64_MODULE_PLTS=y' >> ${B}/.config
+      ;;
+      arm)
+        cp ${S}/arch/arm/configs/multi_v7_defconfig ${B}/.config
+        echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
+        echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
+        echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+      ;;
+      x86_64)
+        cp ${S}/arch/x86/configs/x86_64_defconfig ${B}/.config
+        echo 'CONFIG_IGB=y' >> ${B}/.config
+        # FIXME https://bugs.linaro.org/show_bug.cgi?id=3459
+        # x86 fails to build:
+        # | kernel-source/Makefile:938:
+        # *** "Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y,
+        # please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
+        echo 'CONFIG_UNWINDER_FRAME_POINTER=y' >> ${B}/.config
+        echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
+      ;;
+      i686)
+        cp ${S}/arch/x86/configs/i386_defconfig ${B}/.config
+        echo 'CONFIG_IGB=y' >> ${B}/.config
+        # FIXME https://bugs.linaro.org/show_bug.cgi?id=3459
+        # x86 fails to build:
+        # | kernel-source/Makefile:938:
+        # *** "Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y,
+        # please install libelf-dev, libelf-devel or elfutils-libelf-devel".  Stop.
+        echo 'CONFIG_UNWINDER_FRAME_POINTER=y' >> ${B}/.config
+        echo '# CONFIG_UNWINDER_ORC is not set' >> ${B}/.config
+      ;;
+    esac
+
+    # Check for kernel config fragments. The assumption is that the config
+    # fragment will be specified with the absolute path. For example:
+    #   * ${WORKDIR}/config1.cfg
+    #   * ${S}/config2.cfg
+    # Iterate through the list of configs and make sure that you can find
+    # each one. If not then error out.
+    # NOTE: If you want to override a configuration that is kept in the kernel
+    #       with one from the OE meta data then you should make sure that the
+    #       OE meta data version (i.e. ${WORKDIR}/config1.cfg) is listed
+    #       after the in-kernel configuration fragment.
+    # Check if any config fragments are specified.
+    if [ ! -z "${KERNEL_CONFIG_FRAGMENTS}" ]; then
+        for f in ${KERNEL_CONFIG_FRAGMENTS}; do
+            # Check if the config fragment was copied into the WORKDIR from
+            # the OE meta data
+            if [ ! -e "$f" ]; then
+                echo "Could not find kernel config fragment $f"
+                exit 1
+            fi
+        done
+
+        # Now that all the fragments are located merge them.
+        ( cd ${WORKDIR} && ${S}/scripts/kconfig/merge_config.sh -m -r -O ${B} ${B}/.config ${KERNEL_CONFIG_FRAGMENTS} 1>&2 )
+    fi
+
+    oe_runmake -C ${S} O=${B} olddefconfig
+
+    oe_runmake -C ${S} O=${B} kselftest-merge
+
+    bbplain "Saving defconfig to:\n${B}/defconfig"
+    oe_runmake -C ${B} savedefconfig
+}
+
+do_deploy_append() {
+    cp -a ${B}/defconfig ${DEPLOYDIR}
+    cp -a ${B}/.config ${DEPLOYDIR}/config
+    cp -a ${B}/vmlinux ${DEPLOYDIR}
+    cp ${T}/log.do_compile ${T}/log.do_compile_kernelmodules ${DEPLOYDIR}
+
+    # FIXME 410c fails to build when skales in invoked
+    # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
+    # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
+    # | KeyError: u'ipq8074'
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *sdm845* ) || true
+}
+
+require machine-specific-hooks.inc

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Linux Kernel Selftests (linux-kselftest next)"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
-PV = "4.19+git${SRCPV}"
+PV = "4.20+git${SRCPV}"
 SRCREV = "${AUTOREV}"
 
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel-next"


### PR DESCRIPTION
With the release of Linux 4.20, the following is need to keep up to date:
* add kernel stable RC 4.20,
* update PV for mainline and next,
* update PV for kselftests-next.